### PR TITLE
Remove rewriting arg

### DIFF
--- a/tester/runner
+++ b/tester/runner
@@ -41,12 +41,6 @@
       (table.insert test-files file)))
   test-files)
 
-(fn rewrite-arg [args]
-  (each [i value (ipairs args)]
-    (tset arg i value))
-  (for [i (+ 1 (length args)) (length arg)]
-    (tset arg i nil)))
-
 (fn collect-test-instances [test-files]
   (let [suites (collect [_ test-file (ipairs test-files)]
                  test-file (dofile test-file {:correlate true}))
@@ -67,5 +61,4 @@
       runner (lu.LuaUnit.new)
       test-files (collect-test-files (or test-paths))
       instances (collect-test-instances test-files)]
-  (rewrite-arg runner-args)
-  (runner:runSuiteByInstances instances))
+  (runner:runSuiteByInstances instances runner-args))

--- a/tester/runner
+++ b/tester/runner
@@ -61,4 +61,4 @@
       runner (lu.LuaUnit.new)
       test-files (collect-test-files (or test-paths))
       instances (collect-test-instances test-files)]
-  (runner:runSuiteByInstances instances runner-args))
+  (runner:runSuiteByInstances instances (table.unpack runner-args)))


### PR DESCRIPTION
Requires fixing Luaunit's code to allow passing table of command-line arguments to `runSuiteByInstances`.

Depends on: https://github.com/bluebird75/luaunit/pull/156